### PR TITLE
fix: update git clone url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ export OPENAI_API_KEY='your_api_key_here'
 Run the script with the following command:
 
 ```bash
-python GPTvsGPT.py
+python main.py
 ```
 
 You can customize the personalities and topics directly in the script or build upon the code to create a more interactive experience.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ converse(assistant_1_params, assistant_2_params, "global warming", 5)
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/yourusername/GPTvsGPT.git
+git clone https://github.com/yoheinakajima/GPTvsGPT.git
 cd GPTvsGPT
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+annotated-types==0.6.0
+anyio==3.7.1
+certifi==2023.7.22
+distro==1.8.0
+exceptiongroup==1.1.3
+h11==0.14.0
+httpcore==1.0.1
+httpx==0.25.1
+idna==3.4
+openai==1.1.1
+pydantic==2.4.2
+pydantic_core==2.10.1
+sniffio==1.3.0
+tqdm==4.66.1
+typing_extensions==4.8.0


### PR DESCRIPTION
Noticed a small typo in the clone url within the README, just added your correct url.